### PR TITLE
Changed FastAPI port for possible interference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY start_services.sh /app/
 COPY app /app/app
 
 # Make port 8000 available to the world outside this container
-EXPOSE 8000
+EXPOSE 8001
 EXPOSE 8501
 
 # Set environment variables

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker-compose up --build
 
 3. Access the applications:
 
-- FastAPI: Open your browser and navigate to `http://localhost:8000`. You will see the FastAPI documentation (Swagger UI).
+- FastAPI: Open your browser and navigate to `http://localhost:8001`. You will see the FastAPI documentation (Swagger UI).
 - Streamlit: Open your browser and navigate to `http://localhost:8501`. You will see the Streamlit user interface where you can upload PDF files and get summaries.
 
 ### Usage

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from streamlit_chat import message as chat_message
 def handle_pdf_upload(pdf_file):
     if pdf_file is not None:
         files = {"pdf_file": pdf_file.getvalue()}
-        response = requests.post("http://localhost:8000/upload_pdf/", files=files)
+        response = requests.post("http://localhost:8001/upload_pdf/", files=files)
         response.raise_for_status()
 
         messages = response.json()["conversations"]["messages"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   pdf-summariser:
     build: .
     ports:
-      - "8000:8000"
+      - "8001:8001"
       - "8501:8501"
     volumes:
       - ./app:/app/app

--- a/start_services.sh
+++ b/start_services.sh
@@ -2,7 +2,7 @@
 #!/bin/bash
 
 # Start FastAPI app
-uvicorn app.api.main:app --host 0.0.0.0 --port 8000 --workers 1 --reload &
+uvicorn app.api.main:app --host 0.0.0.0 --port 8001 --workers 1 --reload &
 # Start Streamlit app
 poetry run streamlit run app/main.py --server.port 8501 --server.address 0.0.0.0 &
 


### PR DESCRIPTION
Changed FastAPI port to 8001 for possible interference with the Portainer TCP tunnel server  (on port 8000).
The code is ready to merge.


See https://docs.portainer.io/start/install-ce/server/docker/linux for more details.