### PR TITLE
Windows compatibility & English prompt & READme API key explanation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ EXPOSE 8501
 ENV PYTHONUNBUFFERED=1
 
 # Run the command to start the FastAPI app
+RUN  apt-get update && apt-get install -y dos2unix && dos2unix start_services.sh
 CMD ["sh", "start_services.sh"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ These instructions will help you set up and run the project on your local machin
 git clone https://github.com/your_username/pdf-summarizer.git
 cd pdf-summarizer
 ```
-2. Build and run the Docker container using Docker Compose:
+2. Add your API Key in the docker-compose.yml file
+```
+environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+```
+
+3. Build and run the Docker container using Docker Compose:
 
 This command will build the Docker image, start the container, and run both FastAPI and Streamlit applications.
 ```
@@ -30,7 +36,7 @@ docker-compose up --build
 ```
 
 
-3. Access the applications:
+4. Access the applications:
 
 - FastAPI: Open your browser and navigate to `http://localhost:8001`. You will see the FastAPI documentation (Swagger UI).
 - Streamlit: Open your browser and navigate to `http://localhost:8501`. You will see the Streamlit user interface where you can upload PDF files and get summaries.

--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -1,4 +1,3 @@
-
 import os
 import textwrap
 from typing import Optional
@@ -21,7 +20,8 @@ def set_openai_api_key(API_KEY: Optional[str] = None):
     print("set API_KEY: ", openai.api_key)
 
 def generate_summary(text: str, max_length: int = 100) -> str:
-    prompt = f"下記文章を日本語で{max_length}字で要約して:\n\n{text}\n"
+    # The max_lenght parameter is now ignored.
+    prompt = f"Summarize this document :\n\n{text}\n"
     print(prompt)
 
     completion = openai.ChatCompletion.create(


### PR DESCRIPTION
For Windows compatibility, I add error message when launching "docker-compose up --build" command

Attaching to gpt-pdf-summarizer-pdf-summariser-1
: not foundmarizer-pdf-summariser-1  | start_services.sh: 1:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 3:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 5:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 7:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 8:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 9:
: not foundmarizer-pdf-summariser-1  | start_services.sh: 11: wait
gpt-pdf-summarizer-pdf-summariser-1 exited with code 127